### PR TITLE
remove cgo dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,6 @@ sudo: required
 go:
   - 1.11.x
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-6
-      - g++-6
-
-install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
-
 before_install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:stretch-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
     ca-certificates \
-    libxml2 \
     && apt-get clean
 ADD bin/bblfsh-web /bin/bblfsh-web
 ENTRYPOINT ["/bin/bblfsh-web", "-addr", ":8080"]

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ DEPENDENCIES_DIRECTORY := ./vendor
 BASE_PATH := $(shell pwd)
 ASSETS_PATH := $(BASE_PATH)/build
 
-# Use cgo during build because client-go needs it
-CGO_ENABLED = 1
-
 # Cross compilation doesn't work with cgo
 PKG_OS = linux
 


### PR DESCRIPTION
we switched to client-go.v3 that doesn't require cgo anymore.
But scrips still contain unnecessary steps for cgo support.