### PR TITLE
Return DriverError as 500

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -100,8 +100,7 @@ func (s *Server) handleParse(ctx *gin.Context) {
 		Mode(mode).
 		UAST()
 
-	// bblfsh returns ErrDriverFailure when you feed python driver with java code for example
-	if bblfsh.ErrSyntax.Is(err) || bblfsh.ErrDriverFailure.Is(err) {
+	if bblfsh.ErrSyntax.Is(err) {
 		ctx.JSON(http.StatusBadRequest, jsonError("error parsing UAST: %s", err))
 		return
 	}


### PR DESCRIPTION
Issues with drivers returning wrong error were fixed:

- https://github.com/bblfsh/python-driver/issues/169
- https://github.com/bblfsh/ruby-driver/issues/29

Signed-off-by: Maxim Sukharev <maxim@sourced.tech>