### PR TITLE
Added antiAffinityRules

### DIFF
--- a/.helm_production.yml
+++ b/.helm_production.yml
@@ -6,6 +6,18 @@ ingress:
   globalStaticIpName: bblfsh-play-production
   hostname: play.bblf.sh
 
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+       matchExpressions:
+        - key: app
+          operator: In
+          values:
+            #This value depends of the HELM_RELEASE defined in .travis.yml should be ${HELM_RELEASE}-${CHART_NAME}
+          - bblfsh-web-bblfsh-web
+      topologyKey: kubernetes.io/hostname
+
 replicaCount: 2
 
 nodeSelector:

--- a/.helm_staging.yml
+++ b/.helm_staging.yml
@@ -8,6 +8,18 @@ ingress:
 
 replicaCount: 2
 
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+       matchExpressions:
+        - key: app
+          operator: In
+          values:
+            #This value depends of the HELM_RELEASE defined in .travis.yml should be ${HELM_RELEASE}-${CHART_NAME}
+          - bblfsh-web-bblfsh-web
+      topologyKey: kubernetes.io/hostname
+
 nodeSelector:
   cloud.google.com/gke-nodepool: default-pool
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ jobs:
         - make packages
         - DOCKER_PUSH_MASTER=true make docker-push
         #HELM_RELEASE name is also harcoded in the .helm_staging file in order to use the AntiAffinity Rules.         
-        - HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.0 --set image.tag=dev-$(git rev-parse --short HEAD)-dirty -f .helm_staging.yml" make deploy
+        - HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.1 --set image.tag=dev-$(git rev-parse --short HEAD)-dirty -f .helm_staging.yml" make deploy
     - name: 'Deploy to production'
       stage: release-helm
       script:
         #HELM_RELEASE name is also harcoded in the .helm_production file in order to use the AntiAffinity Rules.                 
-        - B64_CA_CRT=$B64_CA_CRT_PROD SERVICE_ACCOUNT_TOKEN=$SERVICE_ACCOUNT_TOKEN_PROD CLUSTER_ENDPOINT=$CLUSTER_ENDPOINT_PROD HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.0 --set image.tag=$TRAVIS_TAG -f .helm_production.yml" make deploy
+        - B64_CA_CRT=$B64_CA_CRT_PROD SERVICE_ACCOUNT_TOKEN=$SERVICE_ACCOUNT_TOKEN_PROD CLUSTER_ENDPOINT=$CLUSTER_ENDPOINT_PROD HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.1 --set image.tag=$TRAVIS_TAG -f .helm_production.yml" make deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ jobs:
         - make packages
         - DOCKER_PUSH_MASTER=true make docker-push
         #HELM_RELEASE name is also harcoded in the .helm_staging file in order to use the AntiAffinity Rules.         
-        - HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.1 --set image.tag=dev-$(git rev-parse --short HEAD)-dirty -f .helm_staging.yml" make deploy
+        - HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.8.0 --set image.tag=dev-$(git rev-parse --short HEAD)-dirty -f .helm_staging.yml" make deploy
     - name: 'Deploy to production'
       stage: release-helm
       script:
         #HELM_RELEASE name is also harcoded in the .helm_production file in order to use the AntiAffinity Rules.                 
-        - B64_CA_CRT=$B64_CA_CRT_PROD SERVICE_ACCOUNT_TOKEN=$SERVICE_ACCOUNT_TOKEN_PROD CLUSTER_ENDPOINT=$CLUSTER_ENDPOINT_PROD HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.1 --set image.tag=$TRAVIS_TAG -f .helm_production.yml" make deploy
+        - B64_CA_CRT=$B64_CA_CRT_PROD SERVICE_ACCOUNT_TOKEN=$SERVICE_ACCOUNT_TOKEN_PROD CLUSTER_ENDPOINT=$CLUSTER_ENDPOINT_PROD HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.8.0 --set image.tag=$TRAVIS_TAG -f .helm_production.yml" make deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,10 @@ jobs:
       script:
         - make packages
         - DOCKER_PUSH_MASTER=true make docker-push
+        #HELM_RELEASE name is also harcoded in the .helm_staging file in order to use the AntiAffinity Rules.         
         - HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.0 --set image.tag=dev-$(git rev-parse --short HEAD)-dirty -f .helm_staging.yml" make deploy
     - name: 'Deploy to production'
       stage: release-helm
       script:
+        #HELM_RELEASE name is also harcoded in the .helm_production file in order to use the AntiAffinity Rules.                 
         - B64_CA_CRT=$B64_CA_CRT_PROD SERVICE_ACCOUNT_TOKEN=$SERVICE_ACCOUNT_TOKEN_PROD CLUSTER_ENDPOINT=$CLUSTER_ENDPOINT_PROD HELM_RELEASE=bblfsh-web HELM_CHART=bblfsh-web K8S_NAMESPACE=default HELM_ARGS="--repo https://src-d.github.io/charts/ --version 0.7.0 --set image.tag=$TRAVIS_TAG -f .helm_production.yml" make deploy


### PR DESCRIPTION
Added antiAffinityRules to avoid two pods running on the same node.

Waiting to validate the new chart version in [src-d/charts#127](https://github.com/src-d/charts/pull/127)

Not ideal, but we need to hardcode the HELM_RELEASE name in _.helm_staging.yml_ and _.helm_production.yml_ in order to populate the labelSelector rule in the affinity section.

if the _HELM_RELEASE_ value is changed in .travis.yml , it should also be changed in the helm files in order to have the antiAffinityRule working.

Signed-off-by: David Riosalido <driosalido@sourced.tech>