### PR TITLE
Use bblfsh drivers image, fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ For production usage, all static files are served from the go server after being
 
 ## Development
 
-The web client is a Golang application, so in order for all further insturctions to work please make sure it's under `$GOPATH` in your filesystem.
+The web client is a Golang application, so in order for all further instructions to work please make sure it's under `$GOPATH` in your filesystem.
 
 The web client uses an intermediate API that connects to the bblfsh server and serves frontend assets.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ It's a user-friendly tool for testing and studying how Babelfish parses source c
 Babelfish server (v2.9.1 or newer) is required.
 If you don't have it running please read the [getting started](https://doc.bblf.sh/using-babelfish/getting-started.html) guide. You will learn how to use and deploy a bblfsh server.
 
-### Recomended way (using Docker)
+### Recommended way (using Docker)
 
 ```sh
-docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/bblfshd
+docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/bblfshd:latest-drivers
 docker run -p 8080:8080 --link bblfsh bblfsh/web -bblfsh-addr bblfsh:9432
 ```
 


### PR DESCRIPTION
Running the `bblfsh/bblfshd` image is not enough because it comes without drivers, so it cannot parse anything.