### PR TITLE
Use LOG_LEVEL env value to set logrus log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ If you don't want to run the **web client** using our *Docker* image you can dow
 ./bblfsh-web -bblfsh-addr <bblfsh-server-addr>
 ```
 
+You can also configure the server in debug mode passing `--debug` extra flag, and the logging level with the `LOG_LEVEL` environment value:
+
+```sh
+LOG_LEVEL={debug,info,warning error} ./bblfsh-web -bblfsh-addr <bblfsh-server-addr> --debug
+```
+
+If none are set, its default values will be logging level `info`, and server in `ReleaseMode`.
+
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). There is information about the [application architecture](CONTRIBUTING.md#Architecture) and how to [build](CONTRIBUTING.md#Development) from sources.

--- a/server/cmd/bblfsh-web/main.go
+++ b/server/cmd/bblfsh-web/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/bblfsh/web/server"
@@ -18,11 +19,18 @@ var version = "dev"
 func flags() (addr, bblfshAddr string, debug, version bool) {
 	flag.StringVar(&addr, "addr", ":9999", "address in which the server will run")
 	flag.StringVar(&bblfshAddr, "bblfsh-addr", "0.0.0.0:9432", "address of the babelfish server")
-	flag.BoolVar(&debug, "debug", false, "run in debug mode")
+	flag.BoolVar(&debug, "debug", false, "run the server in debug mode")
 	flag.BoolVar(&version, "version", false, "show version and exits")
 	flag.Parse()
 
 	return
+}
+
+var logLevels = map[string]logrus.Level{
+	"debug":   logrus.DebugLevel,
+	"info":    logrus.InfoLevel,
+	"warning": logrus.WarnLevel,
+	"error":   logrus.ErrorLevel,
 }
 
 func main() {
@@ -31,6 +39,10 @@ func main() {
 	if showVersion {
 		fmt.Printf("bblfsh-web %s\n", version)
 		return
+	}
+
+	if level, ok := logLevels[os.Getenv("LOG_LEVEL")]; ok {
+		logrus.SetLevel(level)
 	}
 
 	if !debug {


### PR DESCRIPTION
fix #221

`LOG_LEVEL` can be any of `debug`, `info`, `warning`, `error`
If bblfsh backend is run with `--debug` flag, log level will be `trace`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/web/227)
<!-- Reviewable:end -->
